### PR TITLE
NOVADEV-490: Curated product component

### DIFF
--- a/amplience-automation/automation-files/extensions/product-selector.json.hbs
+++ b/amplience-automation/automation-files/extensions/product-selector.json.hbs
@@ -1,0 +1,23 @@
+{
+  "hubId": "62e96f2bc9e77c0001d98ec5",
+  "name": "product-selector",
+  "label": "Product Selector",
+  "description": "Product Selector",
+  "url": "https://product-selector.extensions.content.amplience.net",
+  "height": 500,
+  "enabledForAllContentTypes": false,
+  "category": "CONTENT_FIELD",
+  "parameters": "{\n  \"backend\": \"sfcc-cors\",\n  \"sfccUrl\": \"{{sfccUrl}}\",\n  \"sfccVersion\": \"{{sfccVersion}}\",\n  \"authSecret\": \"{{authSecret}}\",\n  \"authClientId\": \"{{authClientId}}\",\n  \"authSecret\": \"{{authSecret}}\",\n  \"siteId\": \"{{siteId}}\"\n}",
+  "snippets": [
+    {
+      "label": "Product Selector",
+      "body": "{\n  \"products\": {\n    \"title\": \"Product Selector\",\n    \"type\": \"array\",\n    \"minItems\": 1,\n    \"maxItems\": 10,\n    \"items\": {\n      \"type\": \"string\"\n    },\n    \"ui:extension\": {\n      \"name\": \"product-selector\"\n    }\n  }\n}"
+    }
+  ],
+  "settings": "{\"API\":{\"READ\":false,\"EDIT\":false},\"SANDBOX\":{\"SAME_ORIGIN\":true,\"MODALS\":false,\"NAVIGATION\":false,\"POPUPS\":false,\"POPUP_ESCAPE_SANDBOX\":false,\"DOWNLOADS\":false,\"FORMS\":false}}",
+  "status": "ACTIVE",
+  "createdBy": "4635dbc4-416a-445c-8b51-7969626b077d",
+  "createdDate": "2022-08-09T10:23:27.127Z",
+  "lastModifiedBy": "4635dbc4-416a-445c-8b51-7969626b077d",
+  "lastModifiedDate": "2022-08-09T10:38:55.883Z"
+}

--- a/amplience-automation/automation-files/schema/curated-product.json
+++ b/amplience-automation/automation-files/schema/curated-product.json
@@ -1,0 +1,5 @@
+{
+  "body": "./schemas/curated-product-schema.json",
+  "schemaId": "https://sfcc.com/curated-product",
+  "validationLevel": "CONTENT_TYPE"
+}

--- a/amplience-automation/automation-files/schema/schemas/curated-product-schema.json
+++ b/amplience-automation/automation-files/schema/schemas/curated-product-schema.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://sfcc.com/curated-product",
+
+	"title": "Title",
+	"description": "Description",
+
+	"allOf": [
+		{
+			"$ref": "http://bigcontent.io/cms/schema/v1/core#/definitions/content"
+		}
+	],
+	
+	"type": "object",
+	"properties": {
+		"title": {
+			"title": "Title",
+			"description": "Title for the product scroller",
+			"allOf": [
+				{ "$ref": "http://bigcontent.io/cms/schema/v1/localization#/definitions/localized-string" }
+			]
+		},
+		"products": {
+			"title": "Product List",
+			"type": "array",
+			"minItems": 1,
+			"maxItems": 10,
+			"items": {
+				"type": "string"
+			},
+			"ui:extension": {
+				"name": "product-selector"
+			}
+		}
+	},
+	"propertyOrder": []
+}

--- a/amplience-automation/automation-files/type/curated-product.json
+++ b/amplience-automation/automation-files/type/curated-product.json
@@ -1,0 +1,24 @@
+{
+  "contentTypeUri": "https://sfcc.com/curated-product",
+  "status": "ACTIVE",
+  "settings": {
+    "label": "Curated Product List",
+    "icons": [
+      {
+        "size": 256,
+        "url": "https://bigcontent.io/cms/icons/potter/potter-promo-list.png"
+      }
+    ],
+    "visualizations": [
+      {
+        "label": "Localhost",
+        "templatedUri": "http://localhost:3000/visualization/{{hub.name}}/{{content.sys.id}}/{{vse.domain}}/{{locales}}",
+        "default": true
+      }
+    ],
+    "cards": []
+  },
+  "repositories": [
+    "content"
+  ]
+}

--- a/app/components/amplience/Wrapper/index.jsx
+++ b/app/components/amplience/Wrapper/index.jsx
@@ -23,15 +23,21 @@ const AmplienceWrapper = ({fetch, content, components = componentsMapping}) => {
     const {locale} = useIntl()
 
     useEffect(() => {
+        let active = true
+
         const fetchCont = async () => {
             const data = await client.fetchContent([fetch], locale)
-            setFetchedContent(data.pop())
+            if (active) {
+                setFetchedContent(data.pop())
+            }
         }
         if (fetch) {
             fetchCont()
         } else if (content !== fetchedContent) {
             setFetchedContent(content)
         }
+
+        return () => (active = false)
     }, [fetch, content])
 
     const Component = components[fetchedContent?._meta?.schema]

--- a/app/components/amplience/Wrapper/index.jsx
+++ b/app/components/amplience/Wrapper/index.jsx
@@ -8,10 +8,12 @@ import Section from '../../section'
 import flexibleListSlot from '../flexibleListSlot'
 import {useIntl} from 'react-intl'
 import {AmplienceContext} from '../../../contexts'
+import CuratedProductList from '../curated-product-list'
 
 const componentsMapping = {
     'https://sfcc.com/hero': Hero,
     'https://sfcc.com/section': Section,
+    'https://sfcc.com/curated-product': CuratedProductList,
     'https://sfcc.com/slots/flexiblelist': flexibleListSlot
 }
 

--- a/app/components/amplience/curated-product-list/index.jsx
+++ b/app/components/amplience/curated-product-list/index.jsx
@@ -37,32 +37,44 @@ const selectImage = (product) => {
     return desiredGroup.images[0]
 }
 
-const CuratedProductList = ({...props}) => {
+const CuratedProductList = ({title, products, ...props}) => {
     const api = useCommerceAPI()
-    const [products, setProducts] = useState([])
+    const [apiProducts, setApiProducts] = useState([])
     const [isLoading, setIsLoading] = useState(true)
 
-    useEffect(
+    useEffect(() => {
+        let active = true
+
+        if (products.length === 0) {
+            // No products likely means that the IDs haven't arrived yet.
+            setApiProducts([])
+            setIsLoading(true)
+            return
+        }
+
         handleAsyncError(async () => {
             const response = await api.shopperProducts.getProducts({
                 parameters: {ids: tempMapProductIDs(props.products).join(',')}
             })
 
-            const products = response.data.map((product) => ({
-                ...product,
-                productId: product.id,
-                image: selectImage(product)
-            }))
+            if (active) {
+                const products = response.data.map((product) => ({
+                    ...product,
+                    productId: product.id,
+                    image: selectImage(product)
+                }))
 
-            setProducts(products)
-            setIsLoading(false)
-        }),
-        [api, props.products]
-    )
+                setApiProducts(products)
+                setIsLoading(false)
+            }
+        })()
 
-    //const mappedProducts = tempMapProducts(props.products)
+        return () => (active = false)
+    }, [api, products])
 
-    return <ProductScroller title={props.title} products={products} isLoading={isLoading} />
+    //const mappedProducts = tempMapProducts(products)
+
+    return <ProductScroller title={title} products={apiProducts} isLoading={isLoading} />
 }
 
 CuratedProductList.displayName = 'Curated Product List'

--- a/app/components/amplience/curated-product-list/index.jsx
+++ b/app/components/amplience/curated-product-list/index.jsx
@@ -4,27 +4,6 @@ import {useCommerceAPI} from '../../../commerce-api/contexts'
 import {handleAsyncError} from '../../../commerce-api/utils'
 import ProductScroller from '../../product-scroller'
 
-/*
-const tempMapProducts = (ids) => {
-    return ids.map((id) => ({
-        currency: 'GBP',
-        image: {
-            alt: 'Example Image',
-            disBaseLink: 'https://i8.amplience.net/s/willow/082387',
-            link: 'https://i8.amplience.net/s/willow/082387'
-        },
-        price: 50,
-        name: 'Product ' + id,
-        productName: 'Product ' + id,
-        productId: id
-    }))
-}
-*/
-
-const tempMapProductIDs = () => {
-    return ['74974310M', '78916783M', '25604455M', '25585429M', '69309284M']
-}
-
 const selectImage = (product) => {
     const groups = product.imageGroups
     if (groups == null || groups.length === 0) {
@@ -37,7 +16,7 @@ const selectImage = (product) => {
     return desiredGroup.images[0]
 }
 
-const CuratedProductList = ({title, products, ...props}) => {
+const CuratedProductList = ({title, products}) => {
     const api = useCommerceAPI()
     const [apiProducts, setApiProducts] = useState([])
     const [isLoading, setIsLoading] = useState(true)
@@ -54,7 +33,7 @@ const CuratedProductList = ({title, products, ...props}) => {
 
         handleAsyncError(async () => {
             const response = await api.shopperProducts.getProducts({
-                parameters: {ids: tempMapProductIDs(props.products).join(',')}
+                parameters: {ids: products.join(',')}
             })
 
             if (active) {
@@ -71,8 +50,6 @@ const CuratedProductList = ({title, products, ...props}) => {
 
         return () => (active = false)
     }, [api, products])
-
-    //const mappedProducts = tempMapProducts(products)
 
     return <ProductScroller title={title} products={apiProducts} isLoading={isLoading} />
 }

--- a/app/components/amplience/curated-product-list/index.jsx
+++ b/app/components/amplience/curated-product-list/index.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+//Amplience Rendering Templates
+import ProductScroller from '../../product-scroller'
+
+const tempMapProducts = (ids) => {
+    return ids.map((id) => ({
+        currency: 'GBP',
+        image: {
+            alt: 'Example Image',
+            disBaseLink: 'https://i8.amplience.net/s/willow/082387',
+            link: 'https://i8.amplience.net/s/willow/082387'
+        },
+        price: 50,
+        name: 'Product ' + id,
+        productName: 'Product ' + id,
+        productId: id
+    }))
+}
+
+const CuratedProductList = ({...props}) => {
+    const mappedProducts = tempMapProducts(props.products)
+
+    return <ProductScroller title={props.title} products={mappedProducts} />
+}
+
+CuratedProductList.displayName = 'Curated Product List'
+
+CuratedProductList.propTypes = {
+    title: PropTypes.string,
+    products: PropTypes.array
+}
+
+export default CuratedProductList

--- a/app/pages/home/index.jsx
+++ b/app/pages/home/index.jsx
@@ -79,6 +79,7 @@ const Home = ({productSearchResult, isLoading, homeSlotTop}) => {
             </Heading>
             <AmplienceWrapper fetch={{key: 'hero'}}></AmplienceWrapper>
             <AmplienceWrapper fetch={{key: 'section'}}></AmplienceWrapper>
+            <AmplienceWrapper fetch={{key: 'simple-product-list'}}></AmplienceWrapper>
 
             <Section
                 background={'gray.50'}

--- a/app/ssr.js
+++ b/app/ssr.js
@@ -45,7 +45,8 @@ const { handler } = runtime.createHandler(options, (app) => {
                         'data:',
                         '*.cdn.content.amplience.net',
                         'cdn.media.amplience.net',
-                        '*.staging.bigcontent.io'
+                        '*.staging.bigcontent.io',
+                        'i8.amplience.net'
                     ],
                     'script-src': [
                         "'self'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3388,6 +3388,27 @@
         "@chakra-ui/utils": "1.10.4"
       }
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@ctrl/tinycolor": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz",
@@ -5052,6 +5073,30 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -5907,6 +5952,12 @@
           }
         }
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -7964,6 +8015,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "credit-card-type": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/credit-card-type/-/credit-card-type-9.1.0.tgz",
@@ -8374,6 +8431,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "diff-sequences": {
@@ -10545,6 +10608,27 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -14391,6 +14475,12 @@
           "dev": true
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -19197,6 +19287,41 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -19304,6 +19429,13 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
       "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+      "dev": true,
+      "optional": true
     },
     "ultron": {
       "version": "1.1.1",
@@ -19895,6 +20027,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "v8-to-istanbul": {
@@ -20603,6 +20741,12 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -20762,6 +20906,12 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "js-cookie": "^3.0.1",
     "jwt-decode": "^3.1.2",
     "msw": "^0.28.1",
-    "nanoid": "^3.1.31",
+    "nanoid": "^3.3.4",
     "njwt": "^1.2.0",
     "node-fetch": "^2.6.7",
     "prop-types": "^15.6.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "focus-visible": "^5.2.0",
     "framer-motion": "^3.7.0",
     "full-icu": "^1.3.1",
+    "handlebars": "^4.7.7",
     "helmet": "^4.6.0",
     "hoist-non-react-statics": "^3.3.2",
     "jest-fetch-mock": "^2.1.2",

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -5,13 +5,66 @@ import childProcess from 'child_process'
 
 import _ from 'lodash';
 
+import { compile } from 'handlebars';
+import fs from 'fs';
+import path from 'path';
+
 type Context = {
-  automationDir: string
-  hubId: string
-  clientId: string
-  clientSecret: string
-  contentRepoId: string
-  slotsRepoId: string
+  automationDir: string,
+  hubId: string,
+  clientId: string,
+  clientSecret: string,
+  contentRepoId: string,
+  slotsRepoId: string,
+
+  sfccUrl: string | null,
+  sfccVersion: string | null,
+  authSecret: string | null,
+  authClientId: string | null,
+  siteId: string | null
+}
+
+const recursiveTemplateSearch = async (dir: string, hbsFunc: (path: string) => Promise<void>) => {
+  const files = await fs.promises.readdir(dir);
+
+  for (let file of files) {
+    const fullPath = path.join(dir, file);
+    const isDir = (await fs.promises.stat(fullPath)).isDirectory();
+
+    if (isDir) {
+      await recursiveTemplateSearch(fullPath, hbsFunc);
+    } else if (fullPath.endsWith('.hbs')) {
+      await hbsFunc(fullPath);
+    }
+  }
+}
+
+const compileTemplates = async (dir: string, params: any) => {
+  // Locate and compile hbs templates into the same folder.
+
+  await recursiveTemplateSearch(dir, async (path: string) => {
+    const template = await fs.promises.readFile(path, { encoding: 'utf8' });
+
+    const hbs = compile(template);
+    const result = hbs(params);
+
+    // The path is confirmed to end with .hbs.
+    const newPath = path.substring(0, path.length - ('.hbs'.length));
+
+    await fs.promises.writeFile(newPath, result, { encoding: 'utf8' });
+  });
+}
+
+const clearTemplates = async (dir: string) => {
+  // Clear files generated from hbs templates.
+
+  await recursiveTemplateSearch(dir, async (path: string) => {
+    // The path is confirmed to end with .hbs.
+    const newPath = path.substring(0, path.length - ('.hbs'.length));
+
+    console.log(newPath);
+    await fs.promises.rm(newPath);
+  });
 }
 
 const configureYargs = (yargInstance: Argv): Promise<Arguments> => {
@@ -69,30 +122,71 @@ const configureYargs = (yargInstance: Argv): Promise<Arguments> => {
               required: true,
               type: 'string'
             })
+            .option('sfccUrl', {
+              describe: 'sfcc url',
+              default: null,
+              type: 'string'
+            })
+            .option('sfccVersion', {
+              describe: 'sfcc version',
+              default: null,
+              type: 'string'
+            })
+            .option('authSecret', {
+              describe: 'auth secret',
+              default: null,
+              type: 'string'
+            })
+            .option('authClientId', {
+              describe: 'auth client id',
+              default: null,
+              type: 'string'
+            })
+            .option('siteId', {
+              describe: 'site id',
+              default: null,
+              type: 'string'
+            })
     
         }, async (context: Arguments<Context>): Promise<any> => {
-          console.log(`Configuring dc-cli...`)
-          childProcess.execSync(`./node_modules/.bin/dc-cli configure --clientId ${context.clientId} --clientSecret ${context.clientSecret} --hubId ${context.hubId}`, {stdio: "inherit"});
 
-          console.log(`Importing settings...`)
-          childProcess.execSync(`./node_modules/.bin/dc-cli settings import ${context.automationDir}/settings/hub-settings-62e96f2bc9e77c0001d98ec5-sfcccomposable.json --mapFile ${context.automationDir}/mapping.json`, {stdio: "inherit"});
+          if (context.sfccUrl && context.sfccVersion && context.authSecret && context.authClientId && context.siteId) {
+            console.log(`Compiling templates...`)
+            await compileTemplates(context.automationDir, context);
+          } else {
+            console.log(`Missing SFCC configuration, skipping template compilation. Product selector extension will not be available.`)
+          }
 
-          console.log(`Importing content type schemas...`)
-          childProcess.execSync(`./node_modules/.bin/dc-cli content-type-schema import ${context.automationDir}/schema`, {stdio: "inherit"});
+          try {
+            console.log(`Configuring dc-cli...`)
+            childProcess.execSync(`./node_modules/.bin/dc-cli configure --clientId ${context.clientId} --clientSecret ${context.clientSecret} --hubId ${context.hubId}`, {stdio: "inherit"});
 
-          console.log(`Importing content types...`)
-          childProcess.execSync(`./node_modules/.bin/dc-cli content-type import ${context.automationDir}/type`, {stdio: "inherit"});
+            console.log(`Importing settings...`)
+            childProcess.execSync(`./node_modules/.bin/dc-cli settings import ${context.automationDir}/settings/hub-settings-62e96f2bc9e77c0001d98ec5-sfcccomposable.json --mapFile ${context.automationDir}/mapping.json`, {stdio: "inherit"});
 
-          console.log(`Importing content...`)
-          childProcess.execSync(`./node_modules/.bin/dc-cli content-item import ${context.automationDir}/content/content --baseRepo ${context.contentRepoId} --media true --publish true --mapFile ${context.automationDir}/mapping.json`, {stdio: "inherit"});
+            console.log(`Importing extensions...`)
+            childProcess.execSync(`./node_modules/.bin/dc-cli extension import ${context.automationDir}/extensions`, {stdio: "inherit"});
 
-          console.log(`Importing slots...`)
-          childProcess.execSync(`./node_modules/.bin/dc-cli content-item import ${context.automationDir}/content/slots --baseRepo ${context.slotsRepoId} --mapFile ${context.automationDir}/mapping.json`, {stdio: "inherit"});
+            console.log(`Importing content type schemas...`)
+            childProcess.execSync(`./node_modules/.bin/dc-cli content-type-schema import ${context.automationDir}/schema`, {stdio: "inherit"});
 
-          console.log(`Importing events...`)
-          childProcess.execSync(`./node_modules/.bin/dc-cli event import ${context.automationDir}/events --acceptSnapshotLimits true --schedule true --catchup true --mapFile ${context.automationDir}/mapping.json`, {stdio: "inherit"});
+            console.log(`Importing content types...`)
+            childProcess.execSync(`./node_modules/.bin/dc-cli content-type import ${context.automationDir}/type`, {stdio: "inherit"});
 
-          console.log(`Done!`)
+            console.log(`Importing content...`)
+            childProcess.execSync(`./node_modules/.bin/dc-cli content-item import ${context.automationDir}/content/content --baseRepo ${context.contentRepoId} --media true --publish true --mapFile ${context.automationDir}/mapping.json`, {stdio: "inherit"});
+
+            console.log(`Importing slots...`)
+            childProcess.execSync(`./node_modules/.bin/dc-cli content-item import ${context.automationDir}/content/slots --baseRepo ${context.slotsRepoId} --mapFile ${context.automationDir}/mapping.json`, {stdio: "inherit"});
+
+            console.log(`Importing events...`)
+            childProcess.execSync(`./node_modules/.bin/dc-cli event import ${context.automationDir}/events --acceptSnapshotLimits true --schedule true --catchup true --mapFile ${context.automationDir}/mapping.json`, {stdio: "inherit"});
+
+            console.log(`Done!`)
+          } finally {
+            console.log(`Cleaning up templates...`)
+            await clearTemplates(context.automationDir);
+          }
         })
         .strict()
         .demandCommand(1, 'Please specify at least one command')


### PR DESCRIPTION
- CuratedProductList component, schema and type that uses the product selector extension
  - Just has a title and product list
  - Fetches products from SFCC given an ID list in the content item.
- Added handlebars template support to automation, and the product selector extension to import
  - Still to test with an automation hub. Requires SFCC creds to be provided to automation
  - Copies files and compiles templates to a temp folder. Deletes after done.
- Fixed a bug with AmplienceWrapper where the contained content could update after the component was destroyed